### PR TITLE
Add external training resources index

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,4 +38,5 @@ Pour y contribuer, [créer une Pull Request](https://careerkarma.com/blog/git-pu
 - [Discord](https://github.com/TheHackingProject/bibliotheque-THP/wiki/sommaire_discord)
 - [Outils](https://github.com/TheHackingProject/bibliotheque-THP/wiki/sommaire_outils)
 - [Spécialisations](https://github.com/TheHackingProject/bibliotheque-THP/wiki/liste_spécialisations)
+- [Ressources Pédagogique Externe](https://github.com/TheHackingProject/bibliotheque-THP/wiki/ressources_pedagogique_externe)
 

--- a/formations/liste_formations_intensive.md
+++ b/formations/liste_formations_intensive.md
@@ -1,0 +1,16 @@
+[Index Bibliothèque THP](https://github.com/TheHackingProject/bibliotheque-THP/wiki) > [Ressources Pédagogique Externe](https://github.com/TheHackingProject/bibliotheque-THP/wiki/ressources_pedagogique_externe) > Liste de nos formations intensive
+
+___
+
+# Liste de nos formations intensive
+
+![](https://picsum.photos/1024/400)
+
+## 📄 Description
+
+Voici la liste de nos formations intensives.
+
+- Introduction
+- Fullstack
+- Développeur
+

--- a/formations/liste_formations_non_intensive.md
+++ b/formations/liste_formations_non_intensive.md
@@ -1,0 +1,12 @@
+[Index Bibliothèque THP](https://github.com/TheHackingProject/bibliotheque-THP/wiki) > [Ressources Pédagogique Externe](https://github.com/TheHackingProject/bibliotheque-THP/wiki/ressources_pedagogique_externe) > Liste de nos formations non intensive
+
+___
+
+# Liste de nos formations non intensive
+
+![](https://picsum.photos/1024/400)
+
+## 📄 Description
+
+Cette page présentera prochainement nos formations non intensives.
+

--- a/formations/ressources_pedagogique_externe.md
+++ b/formations/ressources_pedagogique_externe.md
@@ -1,0 +1,17 @@
+[Index Bibliothèque THP](https://github.com/TheHackingProject/bibliotheque-THP/wiki) > Ressources Pédagogique Externe
+
+___
+
+# Ressources Pédagogique Externe
+
+![](https://picsum.photos/1024/400)
+
+## 📄 Description
+
+Cette page répertorie nos formations. Toutes les ressources et liens externes sont désormais listés directement dans la bibliothèque de THP et ne figurent plus sur nos ressources internes.
+
+## 📚 Sommaire
+
+- [Liste de nos formations intensive](https://github.com/TheHackingProject/bibliotheque-THP/wiki/liste_formations_intensive)
+- [Liste de nos formations non intensive](https://github.com/TheHackingProject/bibliotheque-THP/wiki/liste_formations_non_intensive)
+


### PR DESCRIPTION
## Summary
- link to external resources from main index
- list available formations in new external resources page
- add pages for intensive and non intensive training lists

## Testing
- `git log -1 --stat`

------
https://chatgpt.com/codex/tasks/task_e_68810b3f5e8c8320b22424fbe25540a7